### PR TITLE
Use pbr crate for progress bar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_derive = "1.0"
 tar = { git = "https://github.com/redox-os/tar-rs" }
 toml = "0.4"
 version-compare = "0.0.4"
+pbr = { version = "1.0", git = "https://github.com/ids1024/pb", branch = "redox" }
 
 [dependencies.hyper]
 version = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate octavo;
 extern crate serde_derive;
 extern crate tar;
 extern crate toml;
+extern crate pbr;
 
 use octavo::octavo_digest::Digest;
 use octavo::octavo_digest::sha3::Sha512;


### PR DESCRIPTION
![pkg-pb](https://user-images.githubusercontent.com/2263150/27266409-d9e141de-5455-11e7-9bf7-50a387fd09a7.png)

I had to patch pbr with a termion based backend for Redox (https://github.com/ids1024/pb/commit/3434f11276836b7d7f2eb5d9c0b36b0b6c829789). I had to subtract 1 from the column count to make it display on one line (the cursor ended up on the next line, messing things up). That shouldn't be necessary, but I'm not sure where the issue is (orbterm, termion, etc).