### PR TITLE
Use clap for argument parsing, and allow a --target argument to choose which target to download packages for

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tar = { git = "https://github.com/redox-os/tar-rs" }
 toml = "0.4"
 version-compare = "0.0.4"
 pbr = { version = "1.0", git = "https://github.com/ids1024/pb", branch = "redox" }
+clap = {version = "2.25", default-features = false}
 
 [dependencies.hyper]
 version = "0.10"

--- a/src/bin/pkg.rs
+++ b/src/bin/pkg.rs
@@ -90,29 +90,42 @@ fn main() {
     let repo = Repo::new(env!("TARGET"));
 
     let matches = App::new("pkg")
-        .subcommand(
-            SubCommand::with_name("clean")
-            .arg(Arg::with_name("package").multiple(true))
-        ).subcommand(
-            SubCommand::with_name("create")
-            .arg(Arg::with_name("package").multiple(true))
-        ).subcommand(
-            SubCommand::with_name("extract")
-            .arg(Arg::with_name("package").multiple(true))
-        ).subcommand(
-            SubCommand::with_name("fetch")
-            .arg(Arg::with_name("package").multiple(true))
-        ).subcommand(
-            SubCommand::with_name("install")
-            .arg(Arg::with_name("package").multiple(true))
-        ).subcommand(
-            SubCommand::with_name("list")
-            .arg(Arg::with_name("package").multiple(true))
-        ).subcommand(
-            SubCommand::with_name("sign")
-            .arg(Arg::with_name("file").multiple(true))
-        ).subcommand(
-            SubCommand::with_name("upgrade")
+        .subcommand(SubCommand::with_name("clean")
+            .arg(Arg::with_name("package")
+                 .multiple(true)
+                 .required(true)
+            )
+        ).subcommand(SubCommand::with_name("create")
+            .arg(Arg::with_name("package")
+                 .multiple(true)
+                 .required(true)
+            )
+        ).subcommand(SubCommand::with_name("extract")
+            .arg(Arg::with_name("package")
+                 .multiple(true)
+                 .required(true)
+            )
+        ).subcommand(SubCommand::with_name("fetch")
+            .arg(Arg::with_name("package")
+                 .multiple(true)
+                 .required(true)
+            )
+        ).subcommand(SubCommand::with_name("install")
+            .arg(Arg::with_name("package")
+                 .multiple(true)
+                 .required(true)
+            )
+        ).subcommand(SubCommand::with_name("list")
+            .arg(Arg::with_name("package")
+                 .multiple(true)
+                 .required(true)
+            )
+        ).subcommand(SubCommand::with_name("sign")
+            .arg(Arg::with_name("file")
+                 .multiple(true)
+                 .required(true)
+            )
+        ).subcommand(SubCommand::with_name("upgrade")
         ).get_matches();
 
     match matches.subcommand() {

--- a/src/bin/pkg.rs
+++ b/src/bin/pkg.rs
@@ -3,13 +3,15 @@
 extern crate liner;
 extern crate pkgutils;
 extern crate version_compare;
+extern crate clap;
 
 use pkgutils::{Repo, Package, PackageMeta, PackageMetaList};
-use std::{env, process};
+use std::env;
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::path::Path;
 use version_compare::{VersionCompare, CompOp};
+use clap::{App, SubCommand, Arg};
 
 fn upgrade(repo: Repo) -> io::Result<()> {
     let mut local_list = PackageMetaList::new();
@@ -84,176 +86,131 @@ fn upgrade(repo: Repo) -> io::Result<()> {
     Ok(())
 }
 
-fn help() -> io::Result<()> {
-    write!(io::stderr(), "pkg [command] [arguments]\n")?;
-    write!(io::stderr(), "    clean [package] - clean an extracted package\n")?;
-    write!(io::stderr(), "    create [directory] - create a package\n")?;;
-    write!(io::stderr(), "    extract [package] - extract a package\n")?;
-    write!(io::stderr(), "    fetch [package] - download a package\n")?;
-    write!(io::stderr(), "    help - show this help message\n")?;
-    write!(io::stderr(), "    install [package] - install a package\n")?;
-    write!(io::stderr(), "    list [package] - list package contents\n")?;
-    write!(io::stderr(), "    sign [file] - get a file signature\n")?;
-    write!(io::stderr(), "    upgrade - upgrade all packages\n")?;
-
-    Ok(())
-}
-
 fn main() {
     let repo = Repo::new(env!("TARGET"));
 
-    let mut args = env::args().skip(1);
-    if let Some(op) = args.next() {
-        match op.as_str() {
-            "clean" => {
-                let packages: Vec<String> = args.collect();
-                if ! packages.is_empty() {
-                    for package in packages.iter() {
-                        match repo.clean(package) {
-                            Ok(tardir) => {
-                                let _ = write!(io::stderr(), "pkg: clean: {}: cleaned {}\n", package, tardir);
-                            }
-                            Err(err) => {
-                                let _ = write!(io::stderr(), "pkg: clean: {}: failed: {}\n", package, err);
-                            }
-                        }
-                    }
-                } else {
-                    let _ = write!(io::stderr(), "pkg: clean: no packages specified\n");
-                    process::exit(1);
-                }
-            },
-            "create" => {
-                let packages: Vec<String> = args.collect();
-                if ! packages.is_empty() {
-                    for package in packages.iter() {
-                        match repo.create(package) {
-                            Ok(tarfile) => {
-                                let _ = write!(io::stderr(), "pkg: create: {}: created {}\n", package, tarfile);
-                            }
-                            Err(err) => {
-                                let _ = write!(io::stderr(), "pkg: create: {}: failed: {}\n", package, err);
-                            }
-                        }
-                    }
-                } else {
-                    let _ = write!(io::stderr(), "pkg: create: no packages specified\n");
-                    process::exit(1);
-                }
-            },
-            "extract" => {
-                let packages: Vec<String> = args.collect();
-                if ! packages.is_empty() {
-                    for package in packages.iter() {
-                        match repo.extract(package) {
-                            Ok(tardir) => {
-                                let _ = write!(io::stderr(), "pkg: extract: {}: extracted to {}\n", package, tardir);
-                            },
-                            Err(err) => {
-                                let _ = write!(io::stderr(), "pkg: extract: {}: failed: {}\n", package, err);
-                            }
-                        }
-                    }
-                } else {
-                    let _ = write!(io::stderr(), "pkg: extract: no packages specified\n");
-                    process::exit(1);
-                }
-            },
-            "fetch" => {
-                let packages: Vec<String> = args.collect();
-                if ! packages.is_empty() {
-                    for package in packages.iter() {
-                        match repo.fetch(package) {
-                            Ok(pkg) => {
-                                let _ = write!(io::stderr(), "pkg: fetch: {}: fetched {}\n", package, pkg.path().display());
-                            },
-                            Err(err) => {
-                                let _ = write!(io::stderr(), "pkg: fetch: {}: failed: {}\n", package, err);
-                            }
-                        }
-                    }
-                } else {
-                    let _ = write!(io::stderr(), "pkg: fetch: no packages specified\n");
-                    process::exit(1);
-                }
-            },
-            "help" => {
-                let _ = help();
-            },
-            "install" => {
-                let packages: Vec<String> = args.collect();
-                if ! packages.is_empty() {
-                    for package in packages.iter() {
-                        let pkg = if package.ends_with(".tar.gz") {
-                            let path = format!("{}/{}", env::current_dir().unwrap().to_string_lossy(), package);
-                            Package::from_path(&path)
-                        } else {
-                            repo.fetch(package)
-                        };
+    let matches = App::new("pkg")
+        .subcommand(
+            SubCommand::with_name("clean")
+            .arg(Arg::with_name("package").multiple(true))
+        ).subcommand(
+            SubCommand::with_name("create")
+            .arg(Arg::with_name("package").multiple(true))
+        ).subcommand(
+            SubCommand::with_name("extract")
+            .arg(Arg::with_name("package").multiple(true))
+        ).subcommand(
+            SubCommand::with_name("fetch")
+            .arg(Arg::with_name("package").multiple(true))
+        ).subcommand(
+            SubCommand::with_name("install")
+            .arg(Arg::with_name("package").multiple(true))
+        ).subcommand(
+            SubCommand::with_name("list")
+            .arg(Arg::with_name("package").multiple(true))
+        ).subcommand(
+            SubCommand::with_name("sign")
+            .arg(Arg::with_name("file").multiple(true))
+        ).subcommand(
+            SubCommand::with_name("upgrade")
+        ).get_matches();
 
-                        if let Err(err) = pkg.and_then(|mut p| p.install("/")) {
-                            let _ = write!(io::stderr(), "pkg: install: {}: failed: {}\n", package, err);
-                        } else {
-                            let _ = write!(io::stderr(), "pkg: install: {}: succeeded\n", package);
-                        }
+    match matches.subcommand() {
+        ("clean", Some(m)) => {
+            for package in m.values_of("package").unwrap() {
+                match repo.clean(package) {
+                    Ok(tardir) => {
+                        let _ = write!(io::stderr(), "pkg: clean: {}: cleaned {}\n", package, tardir);
                     }
-                } else {
-                    let _ = write!(io::stderr(), "pkg: install: no packages specified\n");
-                    process::exit(1);
-                }
-            },
-            "list" => {
-                let packages: Vec<String> = args.collect();
-                if ! packages.is_empty() {
-                    for package in packages.iter() {
-                        if let Err(err) = repo.fetch(package).and_then(|mut p| p.list()) {
-                            let _ = write!(io::stderr(), "pkg: list: {}: failed: {}\n", package, err);
-                        } else {
-                            let _ = write!(io::stderr(), "pkg: list: {}: succeeded\n", package);
-                        }
-                    }
-                } else {
-                    let _ = write!(io::stderr(), "pkg: list: no packages specified\n");
-                    process::exit(1);
-                }
-            },
-            "sign" => {
-                let files: Vec<String> = args.collect();
-                if ! files.is_empty() {
-                    for file in files.iter() {
-                        match repo.signature(file) {
-                            Ok(signature) => {
-                                let _ = write!(io::stderr(), "pkg: sign: {}: {}\n", file, signature);
-                            },
-                            Err(err) => {
-                                let _ = write!(io::stderr(), "pkg: sign: {}: failed: {}\n", file, err);
-                            }
-                        }
-                    }
-                } else {
-                    let _ = write!(io::stderr(), "pkg: sign: no files specified\n");
-                    process::exit(1);
-                }
-            },
-            "upgrade" => {
-                match upgrade(repo) {
-                    Ok(()) => {
-                        let _ = write!(io::stderr(), "pkg: upgrade: succeeded\n");
-                    },
                     Err(err) => {
-                        let _ = write!(io::stderr(), "pkg: upgrade: failed: {}\n", err);
+                        let _ = write!(io::stderr(), "pkg: clean: {}: failed: {}\n", package, err);
                     }
                 }
-            },
-            _ => {
-                let _ = write!(io::stderr(), "pkg: {}: unknown operation\n", op);
-                let _ = help();
-                process::exit(1);
             }
         }
-    } else {
-        let _ = write!(io::stderr(), "pkg: no operation\n");
-        let _ = help();
-        process::exit(1);
+        ("create", Some(m)) => {
+            for package in m.values_of("package").unwrap() {
+                match repo.create(package) {
+                    Ok(tarfile) => {
+                        let _ = write!(io::stderr(), "pkg: create: {}: created {}\n", package, tarfile);
+                    }
+                    Err(err) => {
+                        let _ = write!(io::stderr(), "pkg: create: {}: failed: {}\n", package, err);
+                    }
+                }
+            }
+        }
+        ("extract", Some(m)) => {
+            for package in m.values_of("package").unwrap() {
+                match repo.extract(package) {
+                    Ok(tardir) => {
+                        let _ = write!(io::stderr(), "pkg: extract: {}: extracted to {}\n", package, tardir);
+                    },
+                    Err(err) => {
+                        let _ = write!(io::stderr(), "pkg: extract: {}: failed: {}\n", package, err);
+                    }
+                }
+            }
+        }
+        ("fetch", Some(m)) => {
+            for package in m.values_of("package").unwrap() {
+                match repo.fetch(package) {
+                    Ok(pkg) => {
+                        let _ = write!(io::stderr(), "pkg: fetch: {}: fetched {}\n", package, pkg.path().display());
+                    },
+                    Err(err) => {
+                        let _ = write!(io::stderr(), "pkg: fetch: {}: failed: {}\n", package, err);
+                    }
+                }
+            }
+        }
+        ("install", Some(m)) => {
+            for package in m.values_of("package").unwrap() {
+                let pkg = if package.ends_with(".tar.gz") {
+                    let path = format!("{}/{}", env::current_dir().unwrap().to_string_lossy(), package);
+                    Package::from_path(&path)
+                } else {
+                    repo.fetch(package)
+                };
+
+                if let Err(err) = pkg.and_then(|mut p| p.install("/")) {
+                    let _ = write!(io::stderr(), "pkg: install: {}: failed: {}\n", package, err);
+                } else {
+                    let _ = write!(io::stderr(), "pkg: install: {}: succeeded\n", package);
+                }
+            }
+        }
+        ("list", Some(m)) => {
+            for package in m.values_of("package").unwrap() {
+                if let Err(err) = repo.fetch(package).and_then(|mut p| p.list()) {
+                    let _ = write!(io::stderr(), "pkg: list: {}: failed: {}\n", package, err);
+                } else {
+                    let _ = write!(io::stderr(), "pkg: list: {}: succeeded\n", package);
+                }
+            }
+        }
+        ("sign", Some(m)) => {
+            for file in m.values_of("file").unwrap() {
+                match repo.signature(file) {
+                    Ok(signature) => {
+                        let _ = write!(io::stderr(), "pkg: sign: {}: {}\n", file, signature);
+                    },
+                    Err(err) => {
+                        let _ = write!(io::stderr(), "pkg: sign: {}: failed: {}\n", file, err);
+                    }
+                }
+            }
+        }
+        ("upgrade", _) => {
+            match upgrade(repo) {
+                Ok(()) => {
+                    let _ = write!(io::stderr(), "pkg: upgrade: succeeded\n");
+                },
+                Err(err) => {
+                    let _ = write!(io::stderr(), "pkg: upgrade: failed: {}\n", err);
+                }
+            }
+        }
+        _ => unreachable!()
     }
 }

--- a/src/bin/pkg.rs
+++ b/src/bin/pkg.rs
@@ -87,10 +87,11 @@ fn upgrade(repo: Repo) -> io::Result<()> {
 }
 
 fn main() {
-    let repo = Repo::new(env!("TARGET"));
-
     let matches = App::new("pkg")
-        .subcommand(SubCommand::with_name("clean")
+        .arg(Arg::with_name("target")
+             .long("target")
+             .takes_value(true)
+        ).subcommand(SubCommand::with_name("clean")
             .arg(Arg::with_name("package")
                  .multiple(true)
                  .required(true)
@@ -127,6 +128,13 @@ fn main() {
             )
         ).subcommand(SubCommand::with_name("upgrade")
         ).get_matches();
+
+    let target = matches.value_of("target")
+        .or(option_env!("TARGET"))
+        .expect(concat!("pkg was not compiled with a target, ",
+                        "and --target was not specified"));
+
+    let repo = Repo::new(target);
 
     match matches.subcommand() {
         ("clean", Some(m)) => {


### PR DESCRIPTION
This also makes it no longer a compilation error is TARGET is not defined. But it that case, it must be specified at run time.