### PR TITLE
Determine default target based on LLVM triple at build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "pkgutils"
 version = "0.1.1"
+build = "build.rs"
 
 [lib]
 name = "pkgutils"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+use std::env;
+
+fn main() {
+    println!("cargo:rustc-env=PKG_DEFAULT_TARGET={}", env::var("TARGET").unwrap());
+}

--- a/src/bin/pkg.rs
+++ b/src/bin/pkg.rs
@@ -129,10 +129,7 @@ fn main() {
         ).subcommand(SubCommand::with_name("upgrade")
         ).get_matches();
 
-    let target = matches.value_of("target")
-        .or(option_env!("TARGET"))
-        .expect(concat!("pkg was not compiled with a target, ",
-                        "and --target was not specified"));
+    let target = matches.value_of("target").unwrap_or(env!("PKG_DEFAULT_TARGET"));
 
     let repo = Repo::new(target);
 


### PR DESCRIPTION
This depends on https://github.com/redox-os/cookbook/pull/35.

It also depends on nighly rust since `rustc-env` was added to cargo since the last release. If this is a problem, it should not be merged until the next release.