### PR TITLE
Do not follow symlinks when creating package

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ impl Repo {
             let encoder = Encoder::new(file)?;
 
             let mut tar = tar::Builder::new(encoder);
+            tar.follow_symlinks(false);
             tar.append_dir_all("", package)?;
 
             let encoder = tar.into_inner()?;


### PR DESCRIPTION
This depends on https://github.com/redox-os/tar-rs/pull/2.